### PR TITLE
Updated reorder-pages request to reflect Readme.io api changes.

### DIFF
--- a/lib/requestor.js
+++ b/lib/requestor.js
@@ -381,7 +381,8 @@ Requestor.uploadOrderRequestBodyFns = {
             requestBodies[doc.version] = requestBodies[doc.version] || [];
             requestBodies[doc.version].push({
                 id: doc._id,
-                parent: doc.categoryId,
+                category: doc.categoryId,
+                parentPage: null,
                 order: doc.order
             });
         });


### PR DESCRIPTION
When running `readmeio-sync upload`, I kept receiving this error:

```
[Error: Order could not be uploaded]
```

I saw in the code that this meant Readme.io was not responding with 200 from the reorder-pages endpoint. Looking into their app, it looks like they've changed the `body` that they expect. Instead of expecting a key of `parent` with the categoryId, it's expecting a key of `category` with the categoryId. 

They also have a key for `parentPage`, which on my end was `null`. There's probably some extra logic that you'd need to look into to see what they're expecting as a value for that key.
