### PR TITLE
use the cookie jar - readme switched to XSRF tokens as cookies

### DIFF
--- a/lib/authenticator.js
+++ b/lib/authenticator.js
@@ -28,7 +28,10 @@ var verifyHeaders = function(headers) {
 var Authenticator = {};
 
 Authenticator.createSession = function(callback) {
-    request(config.auth.LOGIN_URL, function(error, response, body) {
+    request({
+        url: config.auth.LOGIN_URL,
+        jar: cookieJar
+    }, function(error, response, body) {
         errorCheck(error, 'login parsing:');
 
         var $ = cheerio.load(body);


### PR DESCRIPTION
logging into readme fails unless we use the cookies that were set on the login page